### PR TITLE
Replace wp_print_scripts with wp_enqueue_scripts

### DIFF
--- a/easy-swipebox-class.php
+++ b/easy-swipebox-class.php
@@ -181,7 +181,7 @@ class easySwipeBox
         
         // HOOKS //
         add_action('wp_enqueue_scripts', array(__CLASS__, 'easySwipeBox_register_style'), 999);
-        add_action('wp_print_scripts', array(__CLASS__, 'easySwipeBox_register_scripts'), 999);
+        add_action('wp_enqueue_scripts', array(__CLASS__, 'easySwipeBox_register_scripts'), 999);
         add_action('wp_footer', array(__CLASS__, 'easySwipeBox_enqueue_autodetect'));
         add_action('wp_footer', array(__CLASS__, 'easySwipeBox_enqueue_scripts'));
         add_action('admin_menu', array(__CLASS__, 'easySwipeBox_create_menu'));


### PR DESCRIPTION
The plugin fails to load plugin script files in my WordPress 4.3.1 installation until I change `wp_print_scripts` to `wp_enqueue_scripts` on line 184 of easy-swipebox-class.php.

Per WordPress codex: “`wp_print_scripts` should not be used to enqueue styles or scripts since WordPress 3.3… Use `wp_enqueue_scripts` instead.”

[https://codex.wordpress.org/Plugin_API/Action_Reference/wp_print_scripts](https://codex.wordpress.org/Plugin_API/Action_Reference/wp_print_scripts)